### PR TITLE
Fixed battle areas index out of bounds exception in robloxia high location

### DIFF
--- a/src/main/java/content/BattleAreas.java
+++ b/src/main/java/content/BattleAreas.java
@@ -232,7 +232,7 @@ public class BattleAreas {
                     )
                 )
             ),
-            getFamilyArtifacts("man")
+            getFamilyArtifacts("man clan")
         );
 
         contentBattleAreas.add(introFight);

--- a/src/main/java/content/artifacts.java
+++ b/src/main/java/content/artifacts.java
@@ -199,6 +199,11 @@ public class artifacts {
     contentArtifacts.add(cardboardBox);
     contentArtifacts.add(moldyCheese);
     contentArtifacts.add(emptyBeerBottle);
+    contentArtifacts.add(phone);
+    contentArtifacts.add(spoonCollection);
+    contentArtifacts.add(crustyBodyPillow);
+    contentArtifacts.add(bluetoothSpeakerThatPlaysVineBoomSoundEffect);
+    contentArtifacts.add(soakedDoujin);
   }
 
   public static ArrayList<Artifact> getContentArtifacts(){


### PR DESCRIPTION
forgot to initialize the artifacts and call the right artifact family causing there to be a list of size 0.