### PR TITLE
Changed `args[0] != null` to `args.length != 0`

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -56,7 +56,7 @@ class Main{
     Character equipedCharacter = null;
     if(getData().getInt("startupamount") == 0){
       Character player = null;
-      if(args[0] != null){
+      if(args.length != 0){
         System.out.println("\n\n\n\n\nThanks for contributing to the content of this game!\nAs a gift take this.");
         gacha(false, 1, nameTest.substring(0, nameTest.length() - 1));
         player = inventory.getCharacters().get(0);

--- a/src/main/java/content/BattleAreas.java
+++ b/src/main/java/content/BattleAreas.java
@@ -203,7 +203,7 @@ public class BattleAreas {
                                 "phone",
                                 1,
                                 new Buff(""),
-                                new Verbs("scanner", "dealt with"),
+                                new Verbs("scanned", "dealt with"),
                                 "just a scanner phone."
                         ),
                         "a manager"


### PR DESCRIPTION
this is because `args[0] != null` is always checking the first index of args and if no arguments are given then a `ArrayIndexOutOfBoundsException` will occur. Therefore using `args.length != 0` is much better because it checks the length of args.